### PR TITLE
fix: use page.image for social preview images with fallback to profile.jpg

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,12 +21,12 @@
   {% if site.author.twitter_username %}
   <meta name="twitter:creator" content="{{ site.author.twitter_username }}">
   {% endif %}
-  <meta name="twitter:image" content="{{ site.baseurl }}/images/favicons/favicon-194x194.png" />
+  <meta name="twitter:image" content="{% if page.image %}{{ site.baseurl }}{{ page.image }}{% else %}{{ site.baseurl }}/images/profile.jpg{% endif %}" />
 
   <meta property="og:type" content="article">
   <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
   <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html }}{% else %}{{ site.description }}{% endif %}">
-  <meta property="og:image" content="{{ site.baseurl }}/images/favicons/favicon-194x194.png" />
+  <meta property="og:image" content="{% if page.image %}{{ site.baseurl }}{{ page.image }}{% else %}{{ site.baseurl }}/images/profile.jpg{% endif %}" />
 
   <link rel="apple-touch-icon" sizes="57x57" href="{{ site.baseurl }}/images/favicons/apple-touch-icon-57x57.png">
   <link rel="apple-touch-icon" sizes="60x60" href="{{ site.baseurl }}/images/favicons/apple-touch-icon-60x60.png">

--- a/_posts/2026-07-10-ai-coding-frameworks.markdown
+++ b/_posts/2026-07-10-ai-coding-frameworks.markdown
@@ -6,6 +6,7 @@ categories:
   - general
 tags:
   - ai
+image: /images/cover.jpg
 ---
 
 I've used AI in my coding workflow right from the start. At first that meant ChatGPT in a browser, then integrations moved into IDEs. That shift was the real beginning of using a proper "harness" — a framework around an LLM that lets it interact with tools, files, repos, CLIs, issue trackers, and automation systems.


### PR DESCRIPTION
## Summary

Fixes social media preview images (Twitter Cards and Open Graph) so each blog post can specify its own share image instead of always showing the favicon.

## Changes

**_includes/head.html** — Twitter \	witter:image\ and Open Graph \og:image\ meta tags now use \page.image\ when available, falling back to \/images/profile.jpg\ instead of the previous hard-coded favicon.

**_posts/2026-07-10-ai-coding-frameworks.markdown** — Added \image: /images/cover.jpg\ front matter so this post renders with a proper cover image when shared on social platforms.

## Why

Previously every post shared the same 194x194 favicon on Twitter/OG, which made shared links look generic and uninformative. Now each post can declare its own image, and posts without one get a sensible default profile picture.