### PR TITLE
Widen lifecycle diagram with figure layout

### DIFF
--- a/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
+++ b/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
@@ -420,7 +420,11 @@ Event-Driven Ansible
    Agent workflow
 ```
 
-![AFK Engineering Workflow Lifecycle](/assets/afk-lifecycle-diagram.png)
+<figure style="margin-left: -10%; margin-right: -10%;">
+  <img src="/assets/afk-lifecycle-diagram.png" 
+       alt="AFK Engineering Workflow Lifecycle" 
+       style="width:100%;">
+</figure>
 
 A webhook hits my FastAPI application, which validates and normalises
 the event before publishing it into Kafka.


### PR DESCRIPTION
Replaces the plain Markdown image with an HTML figure+img using negative margins so the lifecycle diagram renders wider than the text column for better readability.