### PR TITLE
Fix lifecycle diagram to render full-bleed

### DIFF
--- a/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
+++ b/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
@@ -420,7 +420,7 @@ Event-Driven Ansible
    Agent workflow
 ```
 
-<figure style="margin-left: -10%; margin-right: -10%;">
+<figure style="margin-left: -20%; margin-right: -20%;">
   <img src="/assets/afk-lifecycle-diagram.png" 
        alt="AFK Engineering Workflow Lifecycle" 
        style="width:100%;">


### PR DESCRIPTION
Changes figure margins from -10% to -20% so the diagram breaks out of both wrapper layers and spans the full viewport width.