### PR TITLE
Override CSS constraint for lifecycle diagram

### DIFF
--- a/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
+++ b/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
@@ -420,10 +420,10 @@ Event-Driven Ansible
    Agent workflow
 ```
 
-<figure style="margin-left: -20%; margin-right: -20%;">
-  <img src="/assets/afk-lifecycle-diagram.png" 
-       alt="AFK Engineering Workflow Lifecycle" 
-       style="width:100%;">
+<figure>
+  <img src="/assets/afk-lifecycle-diagram.png"
+       alt="AFK Engineering Workflow Lifecycle"
+       style="display:block; width:140%; max-width:none; margin-left:-20%;">
 </figure>
 
 A webhook hits my FastAPI application, which validates and normalises


### PR DESCRIPTION
The theme's .post img max-width rule was still constraining the diagram. This sets the image itself to 140% width with max-width:none and a negative left margin so the full diagram is readable.