### PR TITLE
Center lifecycle diagram without clipping

### DIFF
--- a/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
+++ b/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
@@ -420,10 +420,10 @@ Event-Driven Ansible
    Agent workflow
 ```
 
-<figure>
+<figure style="text-align:center;">
   <img src="/assets/afk-lifecycle-diagram.png"
        alt="AFK Engineering Workflow Lifecycle"
-       style="display:block; width:140%; max-width:none; margin-left:-20%;">
+       style="display:inline-block; max-width:100%; height:auto;">
 </figure>
 
 A webhook hits my FastAPI application, which validates and normalises


### PR DESCRIPTION
Removes the oversized 140% width and negative margin that clipped the diagram. Uses centered responsive sizing so the complete PNG remains visible on all screen sizes.