### PR TITLE
Widen lifecycle diagram without left clipping

### DIFF
--- a/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
+++ b/_posts/2026-08-08-how-my-afk-engineering-workflow-actually-works.markdown
@@ -420,10 +420,10 @@ Event-Driven Ansible
    Agent workflow
 ```
 
-<figure style="text-align:center;">
+<figure style="margin:0;">
   <img src="/assets/afk-lifecycle-diagram.png"
        alt="AFK Engineering Workflow Lifecycle"
-       style="display:inline-block; max-width:100%; height:auto;">
+       style="display:block; width:140%; max-width:none; height:auto;">
 </figure>
 
 A webhook hits my FastAPI application, which validates and normalises


### PR DESCRIPTION
The diagram was still visually clipped because the article column constrained its display. This keeps the image aligned at the left edge while widening it to 140% without a negative left shift, preserving the complete left side of the diagram.